### PR TITLE
Add in hashtag icons based off https://umbracocommunity.social/custom.css

### DIFF
--- a/frontend/css/modules/hashtag-icons.scss
+++ b/frontend/css/modules/hashtag-icons.scss
@@ -11,11 +11,11 @@ a[href$="/tags/csharp" i]::after{content: "🤖"}
 a[href$="/tags/Hacktoberfest" i]::after{content: "🎃"}
 a[href$="/tags/UmbracoCommunity" i]::after{content: "💙"}
 a[href$="/tags/Friendly" i]::after{content: "💙"}
-a[href$="/tags/codecabin" i]::after,a[href^="/tags/cc2" i]::after{content: "🛖"}
+a[href$="/tags/codecabin" i]::after,a[href*="/tags/cc2" i]::after{content: "🛖"}
 a[href$="/tags/24days" i]::after{content: "📅"}
 a[href$="/tags/meetup" i]::after{content: "🍕"}
 a[href$="/tags/codernails" i]::after{content: "💅🏻"}
-a[href$="/tags/df2" i]::after, a[href^="/tags/duug" i]::after{content: "🦁"}
+a[href*="/tags/df2" i]::after, a[href*="/tags/duug" i]::after{content: "🦁"}
 a[href$="/tags/umbukfest" i]::after{content: "✖️"}
 a[href$="/tags/" i][href*="SecretSanta" i]::after{content: "🧑‍🎄"}
 

--- a/frontend/css/modules/hashtag-icons.scss
+++ b/frontend/css/modules/hashtag-icons.scss
@@ -1,7 +1,7 @@
 ﻿// Based off https://umbracocommunity.social/custom.css and updated to handle URLs not being relative here.
 a[href*="/tags/" i]{white-space: nowrap}
 a[href$="/tags/H5YR" i]::after{content: "✋"}
-a[href$="/tags/Umbraco" i]::after{content: "🦄"}
+a[href*="/tags/Umbraco" i]::after{content: "🦄"}
 a[href$="/tags/UmbracoTees" i]::after{content: "👕"}
 a[href$="/tags/umbraCoffee" i]::after{content: "☕"}
 a[href$="/tags/notacult" i]::after{content: "🙅"}

--- a/frontend/css/modules/hashtag-icons.scss
+++ b/frontend/css/modules/hashtag-icons.scss
@@ -1,0 +1,21 @@
+﻿// Based off https://umbracocommunity.social/custom.css and updated to handle URLs not being relative here.
+a[href*="/tags/" i]{white-space: nowrap}
+a[href$="/tags/H5YR" i]::after{content: "✋"}
+a[href$="/tags/Umbraco" i]::after{content: "🦄"}
+a[href$="/tags/UmbracoTees" i]::after{content: "👕"}
+a[href$="/tags/umbraCoffee" i]::after{content: "☕"}
+a[href$="/tags/notacult" i]::after{content: "🙅"}
+a[href$="/tags/codegarden" i]::after,a[href*="/tags/cg2" i]::after{content: "🦄"}
+a[href$="/tags/dotnet" i]::after{content: "🤖"}
+a[href$="/tags/csharp" i]::after{content: "🤖"}
+a[href$="/tags/Hacktoberfest" i]::after{content: "🎃"}
+a[href$="/tags/UmbracoCommunity" i]::after{content: "💙"}
+a[href$="/tags/Friendly" i]::after{content: "💙"}
+a[href$="/tags/codecabin" i]::after,a[href^="/tags/cc2" i]::after{content: "🛖"}
+a[href$="/tags/24days" i]::after{content: "📅"}
+a[href$="/tags/meetup" i]::after{content: "🍕"}
+a[href$="/tags/codernails" i]::after{content: "💅🏻"}
+a[href$="/tags/df2" i]::after, a[href^="/tags/duug" i]::after{content: "🦁"}
+a[href$="/tags/umbukfest" i]::after{content: "✖️"}
+a[href$="/tags/" i][href*="SecretSanta" i]::after{content: "🧑‍🎄"}
+

--- a/frontend/css/style.scss
+++ b/frontend/css/style.scss
@@ -19,3 +19,4 @@
 @import "modules/friends";    // Example icon styling
 @import "modules/title";    // Example icon styling
 @import "modules/share-to-mastodon";
+@import "modules/hashtag-icons.scss";


### PR DESCRIPTION
Following on from the recent PR to add in the custom emojis, this update adds in the same automatic CSS styling which gets applied to hashtags posted on the Umbraco Community Server to make icons appear after the tag. Most commonly known for causing hashtags like #umbraco to automatically have a unicorn shown after them or the hand icon shown after #h5yr.

This is based off the same custom CSS file on the Mastodon server, but pulled locally and then the attribute selectors modified slightly to account for the fact URLs on h5yr are absolute rather than relative ones on the remote server, so the 'starts with' css pattern matching used there can't be applied directly. In most cases this means 'starts with' (ie ^=) has been replaced with either 'ends with' (ie $=) for tags which were only ever meant to be matched exactly, or 'contains' (ie *=) for tags which were meant to be wildcards, for example anything of the form 'UmbracoSomething' or 'cg2xx'.

As this file is not directly connected to the one on the remote server, it will mean it needs manually updating in the future if new CSS icons are added to the Umbraco community server CSS.