### PR TITLE
FIX Server Sessions expiring quickly and losing 'load more' page position

### DIFF
--- a/Controllers/Mastodon/LoadMorePostsController.cs
+++ b/Controllers/Mastodon/LoadMorePostsController.cs
@@ -33,7 +33,7 @@ namespace h5yr.Controllers.Mastodon
         public async Task<IActionResult> GetPosts(string startId = "")
         {
             // If we're passed in a starting ID, always start a new session otherwise returning users would start loading halfway through
-            var startingPostId = string.IsNullOrEmpty(startId) ? HttpContext.Session.GetString(StartingPostId) : startId;
+            var startingPostId = string.IsNullOrEmpty(startId) ? HttpContext.Request.Cookies[StartingPostId] : startId;
 
             IReadOnlyList<MastodonStatus> posts = Array.Empty<MastodonStatus>();
 
@@ -59,7 +59,7 @@ namespace h5yr.Controllers.Mastodon
                 posts = await _mastodonService.GetStatuses(PageSize, startingPostId);
             }
 
-            HttpContext.Session.SetString(StartingPostId, posts.LastOrDefault()?.Id ?? "");
+            HttpContext.Response.Cookies.Append(StartingPostId, posts.LastOrDefault()?.Id ?? "");
 
             return View("Mastodon/LoadMorePosts", posts);
         }

--- a/Controllers/Mastodon/LoadMorePostsController.cs
+++ b/Controllers/Mastodon/LoadMorePostsController.cs
@@ -35,6 +35,8 @@ namespace h5yr.Controllers.Mastodon
             // If we're passed in a starting ID, always start a new session otherwise returning users would start loading halfway through
             var startingPostId = string.IsNullOrEmpty(startId) ? HttpContext.Request.Cookies[StartingPostId] : startId;
 
+            startingPostId = long.TryParse(startingPostId, out long parsedResult) ? parsedResult.ToString() : ""; // Extra id tamper check
+
             IReadOnlyList<MastodonStatus> posts = Array.Empty<MastodonStatus>();
 
             if (IsOffline)


### PR DESCRIPTION
Small PR to fix an issue that only seems to have appeared off the back off the last release on the actual server.

When using the 'load more posts' button, the user session seems to be expiring very fast. So if you click the button to load in more posts several times in short succession it will work fine. However if you wait about a minute between any page loads, it loses the value in the session and will reset back to page 1.

To fix this, I've just replaced using server side session storage with a local cookie instead to store the paging position, no other changes needed.