### PR TITLE
Updating CSS to mirror latest Custom Emojis added to Mastodon server

### DIFF
--- a/frontend/css/modules/hashtag-icons.scss
+++ b/frontend/css/modules/hashtag-icons.scss
@@ -6,6 +6,8 @@ a[href$="/tags/UmbracoTees" i]::after{content: "👕"}
 a[href$="/tags/umbraCoffee" i]::after{content: "☕"}
 a[href$="/tags/notacult" i]::after{content: "🙅"}
 a[href$="/tags/codegarden" i]::after,a[href*="/tags/cg2" i]::after{content: "🦄"}
+a[href$="/tags/cgRumours" i]::after{ content: "🤫" }
+a[href$="/tags/theSecretStage" i]::after { content: "🧱" }
 a[href$="/tags/dotnet" i]::after{content: "🤖"}
 a[href$="/tags/csharp" i]::after{content: "🤖"}
 a[href$="/tags/Hacktoberfest" i]::after{content: "🎃"}
@@ -18,4 +20,7 @@ a[href$="/tags/codernails" i]::after{content: "💅🏻"}
 a[href*="/tags/df2" i]::after, a[href*="/tags/duug" i]::after{content: "🦁"}
 a[href$="/tags/umbukfest" i]::after{content: "✖️"}
 a[href$="/tags/" i][href*="SecretSanta" i]::after{content: "🧑‍🎄"}
-
+a[href$="/tags/Sustainability" i]::after { content: "🌍" }
+a[href$="/tags/umbfyi" i]::after { content: "🚀" }
+a[href$="/tags/Contentment" i]::after { content: "😌" }
+a[href$="/tags/bellissima" i]::after { content: "👌" }

--- a/frontend/css/modules/hashtag-icons.scss
+++ b/frontend/css/modules/hashtag-icons.scss
@@ -5,7 +5,7 @@ a[href*="/tags/Umbraco" i]::after{content: "🦄"}
 a[href$="/tags/UmbracoTees" i]::after{content: "👕"}
 a[href$="/tags/umbraCoffee" i]::after{content: "☕"}
 a[href$="/tags/notacult" i]::after{content: "🙅"}
-a[href$="/tags/codegarden" i]::after,a[href*="/tags/cg2" i]::after{content: "🦄"}
+a[href$="/tags/codegarden" i]::after,a[href*="/tags/cg2" i]::after{content: "🌷"}
 a[href$="/tags/cgRumours" i]::after{ content: "🤫" }
 a[href$="/tags/theSecretStage" i]::after { content: "🧱" }
 a[href$="/tags/dotnet" i]::after{content: "🤖"}


### PR DESCRIPTION
As mentioned when I copied across the CSS 'emoji' styling for custom hashtags from https://umbracocommunity.social/custom.css so that it would be visually mirrored on h5yr it had the one downside that it would have to be kept manually updated if this ever changed in the future.

Not to be deterred though I have quietly had a visual changes monitor service watching this file on Mastodon since. I'd almost completely forgotten about it being there until it picked up that several new custom emojis were added to the CSS this morning (along with some new header styling classes). I'm guessing this is all in preparation for Codegarden.

To keep H5YR in line, this PR simply brings the same new styles in in to H5YR too adding matching emojis to:-
* #cgRumours
* #theSecretStage
* #sustainability
* #umbfyi
* #contentment
* #bellissima