### PR TITLE
Change css icon for #umbukfest to latest one for 2024 event, implemented on Mastodon server on 24/10

### DIFF
--- a/frontend/css/modules/hashtag-icons.scss
+++ b/frontend/css/modules/hashtag-icons.scss
@@ -18,7 +18,7 @@ a[href$="/tags/24days" i]::after{content: "📅"}
 a[href$="/tags/meetup" i]::after{content: "🍕"}
 a[href$="/tags/codernails" i]::after{content: "💅🏻"}
 a[href*="/tags/df2" i]::after, a[href*="/tags/duug" i]::after{content: "🦁"}
-a[href$="/tags/umbukfest" i]::after{content: "✖️"}
+a[href$="/tags/umbukfest" i]::after{content: "🚇"}
 a[href$="/tags/" i][href*="SecretSanta" i]::after{content: "🧑‍🎄"}
 a[href$="/tags/Sustainability" i]::after { content: "🌍" }
 a[href$="/tags/umbfyi" i]::after { content: "🚀" }


### PR DESCRIPTION
World's smallest PR here (sorry), but my monitor got a notification that the CSS for the Mastodon custom emojis ( https://umbracocommunity.social/custom.css )updated on 24th October. As happened shortly before Codegarden too, the change appears to be part of the prepping for the UmbUKFest event in November. The only change seems to be replacing the X emoji with a train icon, to match the theme for this year.

This PR just mirrors the same CSS change for the H5YR feed.