### PR TITLE
Add mobile responsive layout and hamburger navigation #80

### DIFF
--- a/H5YR/Views/master.cshtml
+++ b/H5YR/Views/master.cshtml
@@ -68,6 +68,10 @@
                         </svg>
                     </a>
                 </div>
+                <input type="checkbox" id="nav-toggle" class="navigation__toggle" aria-hidden="true" />
+                <label for="nav-toggle" class="navigation__toggle-label" aria-label="Toggle navigation">
+                    <span class="navigation__toggle-icon"></span>
+                </label>
                 <nav class="navigation" role="navigation">
                     @{
                         var selection = Umbraco.ContentAtRoot().FirstOrDefault()

--- a/H5YR/frontend/css/base/base.scss
+++ b/H5YR/frontend/css/base/base.scss
@@ -1,5 +1,6 @@
 body {
-  background: #FAEDFF;;
+  background: #faedff;
+  overflow-x: hidden;
 
   &.breakpoint-indicators {
 

--- a/H5YR/frontend/css/base/reset.scss
+++ b/H5YR/frontend/css/base/reset.scss
@@ -4,14 +4,14 @@
  * 1. Set default font family to sans-serif.
  * 2. Prevent iOS text size adjust after orientation change, without disabling
  *    user zoom.
- */ 
+ */
 
 html {
   font-family: sans-serif; /* 1 */
   -ms-text-size-adjust: 100%; /* 2 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }
-  
+
 /**
  * Remove default margin.
  */
@@ -168,6 +168,8 @@ sub {
 
 img {
   border: 0;
+  max-width: 100%;
+  height: auto;
 }
 
 /**
@@ -316,8 +318,8 @@ input {
  * 2. Remove excess padding in IE 8/9/10.
  */
 
-input[type="checkbox"],
-input[type="radio"] {
+input[type='checkbox'],
+input[type='radio'] {
   box-sizing: border-box; /* 1 */
   padding: 0; /* 2 */
 }
@@ -328,8 +330,8 @@ input[type="radio"] {
  * decrement button to change from `default` to `text`.
  */
 
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -339,7 +341,7 @@ input[type="number"]::-webkit-outer-spin-button {
  *    (include `-moz` to future-proof).
  */
 
-input[type="search"] {
+input[type='search'] {
   -webkit-appearance: textfield; /* 1 */
   -moz-box-sizing: content-box;
   -webkit-box-sizing: content-box; /* 2 */
@@ -352,8 +354,8 @@ input[type="search"] {
  * padding (and `textfield` appearance).
  */
 
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
+input[type='search']::-webkit-search-cancel-button,
+input[type='search']::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 

--- a/H5YR/frontend/css/layout/footer.scss
+++ b/H5YR/frontend/css/layout/footer.scss
@@ -1,13 +1,23 @@
 .footer {
   @include font-size(13);
   font-weight: bold;
-  height: 180px;
+  min-height: 180px;
   background: $purple;
   color: $white;
+  padding: 2rem 0;
+
+  @include media($small) {
+    @include font-size(12);
+    padding: 1.5rem 0;
+  }
 }
 
 .footer__inner {
   padding: 2rem 0;
+
+  @include media($small) {
+    padding: 1rem 0;
+  }
 }
 
 .footer__logo {

--- a/H5YR/frontend/css/layout/header.scss
+++ b/H5YR/frontend/css/layout/header.scss
@@ -12,4 +12,9 @@
   flex-flow: row nowrap;
   align-items: center;
   justify-content: space-between;
+  position: relative;
+
+  @include media($small) {
+    flex-flow: row wrap;
+  }
 }

--- a/H5YR/frontend/css/layout/navigation.scss
+++ b/H5YR/frontend/css/layout/navigation.scss
@@ -1,6 +1,98 @@
+//
+// Navigation toggle (hamburger menu)
+//
+
+.navigation__toggle {
+  display: none; // Hide the checkbox always
+}
+
+.navigation__toggle-label {
+  display: none; // Hidden on desktop
+  cursor: pointer;
+  padding: 0.5rem;
+  z-index: 10;
+
+  @include media($medium) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+}
+
+.navigation__toggle-icon {
+  display: block;
+  width: 1.5rem;
+  height: 2px;
+  background: $white;
+  position: relative;
+  transition: background 0.3s ease;
+
+  &::before,
+  &::after {
+    content: '';
+    display: block;
+    width: 1.5rem;
+    height: 2px;
+    background: $white;
+    position: absolute;
+    left: 0;
+    transition: transform 0.3s ease;
+  }
+
+  &::before {
+    top: -6px;
+  }
+
+  &::after {
+    top: 6px;
+  }
+}
+
+// Animate hamburger to X when toggle is checked
+.navigation__toggle:checked
+  ~ .navigation__toggle-label
+  .navigation__toggle-icon {
+  background: transparent;
+
+  &::before {
+    top: 0;
+    transform: rotate(45deg);
+  }
+
+  &::after {
+    top: 0;
+    transform: rotate(-45deg);
+  }
+}
+
+//
+// Navigation
+//
+
 .navigation {
   display: flex;
   flex-flow: row nowrap;
+
+  @include media($medium) {
+    display: none;
+    flex-flow: column nowrap;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: linear-gradient(180deg, #9d50bb, $purple);
+    padding: 1rem 1.5rem;
+    box-shadow: 0 3px 6px rgba($black, 0.2);
+  }
+}
+
+// Show navigation when toggle is checked
+.navigation__toggle:checked ~ .navigation {
+  @include media($medium) {
+    display: flex;
+  }
 }
 
 .navigation__item {
@@ -10,6 +102,12 @@
   font-weight: bold;
   padding: 0.25rem 0.5rem;
   margin: 0 0.25rem;
+
+  @include media($medium) {
+    padding: 0.5rem 0;
+    margin: 0;
+    align-self: flex-start;
+  }
 
   &:first-of-type {
     margin-left: 0;
@@ -28,5 +126,9 @@
     border-bottom: 0;
     padding-bottom: 0.25rem;
     text-decoration: none;
+
+    @include media($medium) {
+      padding-bottom: 0.5rem;
+    }
   }
 }

--- a/H5YR/frontend/css/layout/section.scss
+++ b/H5YR/frontend/css/layout/section.scss
@@ -2,17 +2,33 @@
 
   &.-margin-top {
     margin-top: 3rem;
+
+    @include media($small) {
+      margin-top: 2rem;
+    }
   }
 
   &.-margin-bottom {
     margin-bottom: 3rem;
+
+    @include media($small) {
+      margin-bottom: 2rem;
+    }
   }
 
   &.-overhang-small {
     margin-top: -10vh;
+
+    @include media($small) {
+      margin-top: -5vh;
+    }
   }
 
   &.-overhang-large {
     margin-top: -10vh; // Hero height is calculated on vh, makes sense to use vh here
+
+    @include media($small) {
+      margin-top: -5vh;
+    }
   }
 }

--- a/H5YR/frontend/css/modules/content.scss
+++ b/H5YR/frontend/css/modules/content.scss
@@ -5,6 +5,10 @@
   padding: 2rem 2rem 2.5rem;
   position: relative;
 
+  @include media($small) {
+    padding: 1.25rem 1rem 1.5rem;
+  }
+
   &.-align-center {
     text-align: center;
   }

--- a/H5YR/frontend/css/modules/friends.scss
+++ b/H5YR/frontend/css/modules/friends.scss
@@ -5,8 +5,12 @@
   justify-content: center;
   gap: 2rem;
 
+  @include media($small) {
+    gap: 1rem;
+  }
+
   img {
-	max-width: 100%;
-	height: auto;
+    max-width: 100%;
+    height: auto;
   }
 }

--- a/H5YR/frontend/css/modules/hero.scss
+++ b/H5YR/frontend/css/modules/hero.scss
@@ -6,11 +6,28 @@
   height: 80vh;
   min-height: 400px;
   max-height: 650px;
-  background: linear-gradient(180deg, #9D50BB, $purple);
+  background: linear-gradient(180deg, #9d50bb, $purple);
+
+  @include media($medium) {
+    height: 60vh;
+    min-height: 300px;
+    max-height: 500px;
+  }
+
+  @include media($small) {
+    height: 50vh;
+    min-height: 250px;
+    max-height: 400px;
+  }
 
   &.-small {
     height: 30vh;
     min-height: 200px;
+
+    @include media($small) {
+      height: 25vh;
+      min-height: 150px;
+    }
   }
 }
 
@@ -19,6 +36,8 @@
   flex-flow: row wrap;
   justify-content: center;
   align-items: center;
+  width: 100%;
+  padding: 0 1rem;
 }
 
 .hero__animation {
@@ -27,4 +46,12 @@
   min-height: 50vh;
   z-index: 0;
   position: relative;
+
+  @include media($medium) {
+    min-height: 35vh;
+  }
+
+  @include media($small) {
+    min-height: 25vh;
+  }
 }

--- a/H5YR/frontend/css/modules/tweets.scss
+++ b/H5YR/frontend/css/modules/tweets.scss
@@ -1,9 +1,28 @@
-.tweetgrid-panel { -webkit-column-width: 366px; column-width: 366px; -webkit-column-gap: 30px; column-gap: 30px;}
-.tweetgrid-panel .tweetcard { -webkit-column-break-inside: avoid; break-inside: avoid-column; }
-.tweetgrid-panel .tweetcard + .tweetcard { margin-top: 30px; }
+.tweetgrid-panel {
+  -webkit-column-width: 366px;
+  column-width: 366px;
+  -webkit-column-gap: 30px;
+  column-gap: 30px;
 
-.tweets .pagination { padding: 60px 20px; text-align: center; }
+  @include media($small) {
+    -webkit-column-width: auto;
+    column-width: auto;
+    -webkit-column-count: 1;
+    column-count: 1;
+  }
+}
+.tweetgrid-panel .tweetcard {
+  -webkit-column-break-inside: avoid;
+  break-inside: avoid-column;
+}
+.tweetgrid-panel .tweetcard + .tweetcard {
+  margin-top: 30px;
+}
 
+.tweets .pagination {
+  padding: 60px 20px;
+  text-align: center;
+}
 
 .load-more-container {
   margin-top: 30px;
@@ -49,6 +68,11 @@
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
   grid-gap: 30px;
   grid-auto-flow: dense;
+
+  @include media($small) {
+    grid-template-columns: 1fr;
+    grid-gap: 20px;
+  }
 }
 
 .tweet__card {
@@ -76,7 +100,8 @@
 .tweet__user-detail {
   font-weight: bold;
 
-  a, time {
+  a,
+  time {
     font-weight: bold;
   }
 
@@ -100,13 +125,11 @@
     word-break: break-word;
     text-decoration: none;
   }
-  
-  .inline_emoji
-  {
-	height: 1.3rem;
-	vertical-align: middle;
+
+  .inline_emoji {
+    height: 1.3rem;
+    vertical-align: middle;
   }
-  
 }
 
 .tweet__actions {


### PR DESCRIPTION
## Summary

Makes the site mobile responsive with a hamburger menu for navigation on smaller screens. No branding or design changes — same colors, fonts, and visual identity.

Fixes #80 

## Changes

- Added CSS-only hamburger menu (checkbox toggle) for screens below 768px
- Hero section scales down on medium/small viewports
- Tweet grid falls to single column on mobile
- Footer uses min-height instead of fixed height to prevent content clipping
- Content blocks reduce padding on small screens
- Added overflow-x: hidden and responsive image defaults to prevent horizontal scroll
- Section margins/overhangs reduced on mobile

## Files changed

- `H5YR/Views/master.cshtml` — hamburger toggle markup
- `H5YR/frontend/css/base/base.scss` — overflow-x hidden
- `H5YR/frontend/css/base/reset.scss` — responsive images
- `H5YR/frontend/css/layout/header.scss` — relative positioning for dropdown
- `H5YR/frontend/css/layout/navigation.scss` — hamburger + mobile dropdown
- `H5YR/frontend/css/layout/footer.scss` — flexible height
- `H5YR/frontend/css/layout/section.scss` — reduced mobile spacing
- `H5YR/frontend/css/modules/hero.scss` — scaled viewports
- `H5YR/frontend/css/modules/content.scss` — reduced mobile padding
- `H5YR/frontend/css/modules/tweets.scss` — single column on mobile
- `H5YR/frontend/css/modules/friends.scss` — reduced gap

## Testing

- Verified Vite compiles all SCSS without errors
- Hamburger appears below 768px, nav links stack vertically
- Squiggle hover animation preserved on mobile (scoped to text width)
- No JavaScript added — pure CSS toggle
