### PR TITLE
Feature/new db table for stats

### DIFF
--- a/H5YR.Core/Composers/DiComposer.cs
+++ b/H5YR.Core/Composers/DiComposer.cs
@@ -42,6 +42,10 @@ namespace H5YR.Core.Composers
             builder.Services.AddSingleton<IWidgetJwtService, WidgetJwtService>();
             builder.Services.Configure<WidgetSettings>(builder.Config.GetSection("WidgetSettings"));
 
+            // Feed item log
+            builder.Services.AddSingleton<IFeedItemLogStore, FeedItemLogStore>();
+            builder.Services.AddSingleton<FeedItemLogBackfillService>();
+
             // Community stats
             builder.Services.AddSingleton<ICommunityStatsService, CommunityStatsService>();
         }

--- a/H5YR.Core/Composers/FeedItemLogBackfillComposer.cs
+++ b/H5YR.Core/Composers/FeedItemLogBackfillComposer.cs
@@ -1,0 +1,75 @@
+using H5YR.Core.Services;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Services;
+
+namespace H5YR.Core.Composers
+{
+    public class FeedItemLogBackfillComposer : ComponentComposer<FeedItemLogBackfillComponent>, IComposer
+    {
+    }
+
+    public class FeedItemLogBackfillComponent : IAsyncComponent
+    {
+        private const string BackfillDoneKey = "H5YR.FeedItemLogBackfill.Done";
+
+        private readonly ILogger<FeedItemLogBackfillComponent> _logger;
+        private readonly IKeyValueService _keyValueService;
+        private readonly IRuntimeState _runtimeState;
+        private readonly FeedItemLogBackfillService _backfillService;
+
+        public FeedItemLogBackfillComponent(
+            ILogger<FeedItemLogBackfillComponent> logger,
+            IKeyValueService keyValueService,
+            IRuntimeState runtimeState,
+            FeedItemLogBackfillService backfillService)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _keyValueService = keyValueService ?? throw new ArgumentNullException(nameof(keyValueService));
+            _runtimeState = runtimeState ?? throw new ArgumentNullException(nameof(runtimeState));
+            _backfillService = backfillService ?? throw new ArgumentNullException(nameof(backfillService));
+        }
+
+        public async Task InitializeAsync(bool isRestarting, CancellationToken cancellationToken)
+        {
+            if (_runtimeState.Level < RuntimeLevel.Run)
+            {
+                return;
+            }
+
+            var alreadyDone = _keyValueService.GetValue(BackfillDoneKey);
+            if (alreadyDone == "true")
+            {
+                _logger.LogDebug("FeedItemLog back-fill already completed, skipping.");
+                return;
+            }
+
+            _logger.LogInformation("Running one-time FeedItemLog back-fill.");
+
+            try
+            {
+                _backfillService.BackfillFromWidget();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Widget back-fill failed.");
+            }
+
+            try
+            {
+                await _backfillService.BackfillFromMastodonAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Mastodon back-fill failed.");
+            }
+
+            _keyValueService.SetValue(BackfillDoneKey, "true");
+            _logger.LogInformation("FeedItemLog back-fill complete. Flag set.");
+        }
+
+        public Task TerminateAsync(bool isRestarting, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+}

--- a/H5YR.Core/Composers/FeedItemLogStoreComposer.cs
+++ b/H5YR.Core/Composers/FeedItemLogStoreComposer.cs
@@ -1,0 +1,60 @@
+using H5YR.Core.Data.Migrations;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
+
+namespace H5YR.Core.Composers
+{
+    public class FeedItemLogStoreComposer : ComponentComposer<FeedItemLogStoreComponent>, IComposer
+    {
+    }
+
+    public class FeedItemLogStoreComponent : IAsyncComponent
+    {
+        private readonly ICoreScopeProvider _coreScopeProvider;
+        private readonly IMigrationPlanExecutor _migrationPlanExecutor;
+        private readonly IKeyValueService _keyValueService;
+        private readonly ILogger<FeedItemLogStoreComponent> _logger;
+        private readonly IRuntimeState _runtimeState;
+
+        public FeedItemLogStoreComponent(
+            ICoreScopeProvider coreScopeProvider,
+            IMigrationPlanExecutor migrationPlanExecutor,
+            IKeyValueService keyValueService,
+            ILogger<FeedItemLogStoreComponent> logger,
+            IRuntimeState runtimeState)
+        {
+            _coreScopeProvider = coreScopeProvider ?? throw new ArgumentNullException(nameof(coreScopeProvider));
+            _migrationPlanExecutor = migrationPlanExecutor ?? throw new ArgumentNullException(nameof(migrationPlanExecutor));
+            _keyValueService = keyValueService ?? throw new ArgumentNullException(nameof(keyValueService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _runtimeState = runtimeState ?? throw new ArgumentNullException(nameof(runtimeState));
+        }
+
+        public Task InitializeAsync(bool isRestarting, CancellationToken cancellationToken)
+        {
+            if (_runtimeState.Level < RuntimeLevel.Run)
+            {
+            }
+
+            var migrationPlan = new MigrationPlan("FeedItemLogCreateTableMigrationPlan1");
+
+            migrationPlan = migrationPlan.From(string.Empty)
+                .To<FeedItemLogCreateTableMigration>(nameof(FeedItemLogCreateTableMigration));
+
+            var upgrader = new Upgrader(migrationPlan);
+
+            return upgrader.ExecuteAsync(_migrationPlanExecutor, _coreScopeProvider, _keyValueService);
+        }
+
+        public Task TerminateAsync(bool isRestarting, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/H5YR.Core/Data/Constants/FeedItemLogSchemaConstants.cs
+++ b/H5YR.Core/Data/Constants/FeedItemLogSchemaConstants.cs
@@ -1,0 +1,19 @@
+using H5YR.Core.Data.Entities;
+
+namespace H5YR.Core.Data.Constants
+{
+    public static class FeedItemLogSchemaConstants
+    {
+        public const string TableName = "FeedItemLog";
+
+        public const string PrimaryKey = Id;
+
+        public const string Id = nameof(FeedItemLog.Id);
+
+        public const string ExternalId = nameof(FeedItemLog.ExternalId);
+
+        public const string Source = nameof(FeedItemLog.Source);
+
+        public const string CreatedAt = nameof(FeedItemLog.CreatedAt);
+    }
+}

--- a/H5YR.Core/Data/Entities/FeedItemLog.cs
+++ b/H5YR.Core/Data/Entities/FeedItemLog.cs
@@ -1,0 +1,37 @@
+using H5YR.Core.Data.Constants;
+using NPoco;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+
+namespace H5YR.Core.Data.Entities
+{
+    [TableName(FeedItemLogSchemaConstants.TableName)]
+    [PrimaryKey(FeedItemLogSchemaConstants.PrimaryKey, AutoIncrement = true)]
+    [ExplicitColumns]
+    public class FeedItemLog
+    {
+        [PrimaryKeyColumn(AutoIncrement = true)]
+        [Column(FeedItemLogSchemaConstants.Id)]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// The original ID of the feed item (e.g. Mastodon status ID or widget row ID).
+        /// Used to prevent duplicate inserts.
+        /// </summary>
+        [Column(FeedItemLogSchemaConstants.ExternalId)]
+        [Length(255)]
+        public string ExternalId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// "mastodon" or "widget"
+        /// </summary>
+        [Column(FeedItemLogSchemaConstants.Source)]
+        [Length(50)]
+        public string Source { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The original timestamp of the feed item, used for date-based stats.
+        /// </summary>
+        [Column(FeedItemLogSchemaConstants.CreatedAt)]
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/H5YR.Core/Data/Interfaces/IFeedItemLogStore.cs
+++ b/H5YR.Core/Data/Interfaces/IFeedItemLogStore.cs
@@ -1,0 +1,13 @@
+using H5YR.Core.Data.Entities;
+
+namespace H5YR.Core.Data.Interfaces
+{
+    public interface IFeedItemLogStore
+    {
+        IEnumerable<FeedItemLog> GetAll();
+        bool Exists(string externalId);
+        void Save(FeedItemLog poco);
+        void SaveRange(IEnumerable<FeedItemLog> items);
+        void Delete(FeedItemLog poco);
+    }
+}

--- a/H5YR.Core/Data/Migrations/FeedItemLogCreateTableMigration.cs
+++ b/H5YR.Core/Data/Migrations/FeedItemLogCreateTableMigration.cs
@@ -1,0 +1,39 @@
+using H5YR.Core.Data.Constants;
+using H5YR.Core.Data.Entities;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Migrations;
+
+namespace H5YR.Core.Data.Migrations
+{
+    public class FeedItemLogCreateTableMigration : AsyncMigrationBase
+    {
+        private readonly ILogger<FeedItemLogCreateTableMigration> _logger;
+        private readonly ICoreScopeProvider _scopeProvider;
+
+        public FeedItemLogCreateTableMigration(IMigrationContext context, ILogger<FeedItemLogCreateTableMigration> logger, ICoreScopeProvider scopeProvider) : base(context)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _scopeProvider = scopeProvider ?? throw new ArgumentNullException(nameof(scopeProvider));
+        }
+
+        protected override async Task MigrateAsync()
+        {
+            _logger.LogDebug("Running migration.");
+
+            using (var scope = _scopeProvider.CreateCoreScope())
+            {
+                if (!TableExists(FeedItemLogSchemaConstants.TableName))
+                {
+                    Create.Table<FeedItemLog>().Do();
+                    scope.Complete();
+                    return;
+                }
+                scope.Complete();
+            }
+
+            _logger.LogDebug(
+                $"The database table {FeedItemLogSchemaConstants.TableName} already exists, skipping.");
+        }
+    }
+}

--- a/H5YR.Core/Data/Stores/FeedItemLogStore.cs
+++ b/H5YR.Core/Data/Stores/FeedItemLogStore.cs
@@ -1,0 +1,72 @@
+using H5YR.Core.Data.Constants;
+using H5YR.Core.Data.Entities;
+using H5YR.Core.Data.Interfaces;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Infrastructure.Scoping;
+
+namespace H5YR.Core.Data.Stores
+{
+    public class FeedItemLogStore : IFeedItemLogStore
+    {
+        private readonly ILogger<FeedItemLogStore> _logger;
+        private readonly IScopeProvider _scopeProvider;
+
+        public FeedItemLogStore(ILogger<FeedItemLogStore> logger, IScopeProvider scopeProvider)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _scopeProvider = scopeProvider ?? throw new ArgumentNullException(nameof(scopeProvider));
+        }
+
+        public IEnumerable<FeedItemLog> GetAll()
+        {
+            using (var scope = _scopeProvider.CreateScope())
+            {
+                var items = scope.Database.Fetch<FeedItemLog>();
+                scope.Complete();
+                return items;
+            }
+        }
+
+        public bool Exists(string externalId)
+        {
+            using (var scope = _scopeProvider.CreateScope())
+            {
+                var count = scope.Database.ExecuteScalar<int>(
+                    $"SELECT COUNT(1) FROM {FeedItemLogSchemaConstants.TableName} WHERE {FeedItemLogSchemaConstants.ExternalId} = @0",
+                    externalId);
+                scope.Complete();
+                return count > 0;
+            }
+        }
+
+        public void Save(FeedItemLog poco)
+        {
+            using (var scope = _scopeProvider.CreateScope())
+            {
+                scope.Database.Insert(poco);
+                scope.Complete();
+            }
+        }
+
+        public void SaveRange(IEnumerable<FeedItemLog> items)
+        {
+            using (var scope = _scopeProvider.CreateScope())
+            {
+                foreach (var item in items)
+                {
+                    scope.Database.Insert(item);
+                }
+                scope.Complete();
+            }
+        }
+
+        public void Delete(FeedItemLog poco)
+        {
+            using (var scope = _scopeProvider.CreateScope())
+            {
+                scope.Database.Delete(poco);
+                scope.Complete();
+            }
+        }
+    }
+}

--- a/H5YR.Core/Services/CommunityStatsService.cs
+++ b/H5YR.Core/Services/CommunityStatsService.cs
@@ -8,80 +8,43 @@ namespace H5YR.Core.Services
   public class CommunityStatsService : ICommunityStatsService
   {
     private readonly ILogger<CommunityStatsService> _logger;
-    private readonly IPostCounterStore _postCounterStore;
+    private readonly IFeedItemLogStore _feedItemLogStore;
     private readonly IWidgetH5yrStore _widgetH5yrStore;
     private readonly IMastodonService _mastodonService;
 
     public CommunityStatsService(
         ILogger<CommunityStatsService> logger,
-        IPostCounterStore postCounterStore,
+        IFeedItemLogStore feedItemLogStore,
         IWidgetH5yrStore widgetH5yrStore,
         IMastodonService mastodonService)
     {
       _logger = logger;
-      _postCounterStore = postCounterStore;
+      _feedItemLogStore = feedItemLogStore;
       _widgetH5yrStore = widgetH5yrStore;
       _mastodonService = mastodonService;
     }
 
     public async Task<CommunityStatsViewModel> GetStats()
     {
-      var totalMastodon = _postCounterStore.GetPostCount();
-      var totalWidget = _widgetH5yrStore.GetTotalCount();
+      // Use FeedItemLog as the single source of truth for all counts and timeline data
+      var allLogItems = _feedItemLogStore.GetAll().ToList();
 
-      var postCounters = _postCounterStore.GetAll()
-          .OrderBy(p => p.Date)
+      var totalH5yrs = allLogItems.Count;
+      var totalWidget = allLogItems.Count(x => x.Source == "widget");
+
+      // Build activity timeline by grouping log items by month, sorted chronologically
+      var activityTimeline = allLogItems
+          .GroupBy(x => new DateTime(x.CreatedAt.Year, x.CreatedAt.Month, 1))
+          .OrderBy(g => g.Key)
+          .Select(g => new ActivityDataPoint
+          {
+            Label = g.Key.ToString("MMM yyyy"),
+            Count = g.Count()
+          })
           .ToList();
 
-      var activityTimeline = new List<ActivityDataPoint>();
-
-      if (postCounters.Count > 0)
-      {
-        var monthlySnapshots = postCounters
-            .GroupBy(p => new { p.Date.Year, p.Date.Month })
-            .OrderBy(g => g.Key.Year).ThenBy(g => g.Key.Month)
-            .Select(g => new
-            {
-              Label = new DateTime(g.Key.Year, g.Key.Month, 1).ToString("MMM yyyy"),
-              g.OrderByDescending(x => x.Date).First().Quantity
-            })
-            .ToList();
-
-        for (int i = 0; i < monthlySnapshots.Count; i++)
-        {
-          var count = i == 0
-              ? monthlySnapshots[i].Quantity
-              : monthlySnapshots[i].Quantity - monthlySnapshots[i - 1].Quantity;
-
-          activityTimeline.Add(new ActivityDataPoint
-          {
-            Label = monthlySnapshots[i].Label,
-            Count = Math.Max(0, count)
-          });
-        }
-      }
-
-      // Merge widget submissions into the timeline
-      var allWidgets = _widgetH5yrStore.GetAll();
-      var widgetByMonth = allWidgets
-          .GroupBy(w => new { w.CreatedAt.Year, w.CreatedAt.Month })
-          .ToDictionary(
-              g => new DateTime(g.Key.Year, g.Key.Month, 1).ToString("MMM yyyy"),
-              g => g.Count());
-
-      foreach (var point in activityTimeline)
-      {
-        if (widgetByMonth.TryGetValue(point.Label, out var widgetCount))
-        {
-          point.Count += widgetCount;
-          widgetByMonth.Remove(point.Label);
-        }
-      }
-
-      foreach (var kvp in widgetByMonth.OrderBy(k => k.Key))
-      {
-        activityTimeline.Add(new ActivityDataPoint { Label = kvp.Key, Count = kvp.Value });
-      }
+      var todayStart = DateTime.UtcNow.Date;
+      var todayCount = allLogItems.Count(x => x.CreatedAt >= todayStart);
 
       var topContributors = new List<ContributorDataPoint>();
 
@@ -107,6 +70,7 @@ namespace H5YR.Core.Services
         _logger.LogWarning(ex, "Failed to fetch Mastodon posts for stats");
       }
 
+      var allWidgets = _widgetH5yrStore.GetAll();
       var widgetContributors = allWidgets
           .GroupBy(w => new { w.ExternalUserId, w.AuthProvider })
           .OrderByDescending(g => g.Count())
@@ -129,12 +93,9 @@ namespace H5YR.Core.Services
           .Take(10)
           .ToList();
 
-      var todayStart = DateTime.UtcNow.Date;
-      var todayCount = allWidgets.Count(w => w.CreatedAt >= todayStart);
-
       return new CommunityStatsViewModel
       {
-        TotalH5yrs = totalMastodon + totalWidget,
+        TotalH5yrs = totalH5yrs,
         TotalWidgetSubmissions = totalWidget,
         TodayCount = todayCount,
         ActivityTimeline = activityTimeline,

--- a/H5YR.Core/Services/FeedItemLogBackfillService.cs
+++ b/H5YR.Core/Services/FeedItemLogBackfillService.cs
@@ -1,0 +1,122 @@
+using H5YR.Core.Data.Entities;
+using H5YR.Core.Data.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace H5YR.Core.Services
+{
+    public class FeedItemLogBackfillService
+    {
+        private readonly ILogger<FeedItemLogBackfillService> _logger;
+        private readonly IFeedItemLogStore _feedItemLogStore;
+        private readonly IWidgetH5yrStore _widgetH5yrStore;
+        private readonly IMastodonService _mastodonService;
+
+        private const int MastodonPageSize = 40;
+        private static readonly TimeSpan BackfillWindow = TimeSpan.FromDays(90);
+
+        public FeedItemLogBackfillService(
+            ILogger<FeedItemLogBackfillService> logger,
+            IFeedItemLogStore feedItemLogStore,
+            IWidgetH5yrStore widgetH5yrStore,
+            IMastodonService mastodonService)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _feedItemLogStore = feedItemLogStore ?? throw new ArgumentNullException(nameof(feedItemLogStore));
+            _widgetH5yrStore = widgetH5yrStore ?? throw new ArgumentNullException(nameof(widgetH5yrStore));
+            _mastodonService = mastodonService ?? throw new ArgumentNullException(nameof(mastodonService));
+        }
+
+        public void BackfillFromWidget()
+        {
+            _logger.LogInformation("Starting FeedItemLog back-fill from WidgetH5yr.");
+
+            var allWidgetItems = _widgetH5yrStore.GetAll();
+            var toInsert = new List<FeedItemLog>();
+
+            foreach (var w in allWidgetItems)
+            {
+                var externalId = $"widget_{w.Id}";
+                if (!_feedItemLogStore.Exists(externalId))
+                {
+                    toInsert.Add(new FeedItemLog
+                    {
+                        ExternalId = externalId,
+                        Source = "widget",
+                        CreatedAt = w.CreatedAt
+                    });
+                }
+            }
+
+            if (toInsert.Count > 0)
+            {
+                _feedItemLogStore.SaveRange(toInsert);
+                _logger.LogInformation("Back-filled {Count} widget items into FeedItemLog.", toInsert.Count);
+            }
+            else
+            {
+                _logger.LogInformation("No new widget items to back-fill.");
+            }
+        }
+
+        public async Task BackfillFromMastodonAsync()
+        {
+            _logger.LogInformation("Starting FeedItemLog back-fill from Mastodon (window: {Days} days).", BackfillWindow.Days);
+
+            var cutoff = DateTime.UtcNow - BackfillWindow;
+            string? maxId = null;
+            int totalInserted = 0;
+            int pageCount = 0;
+
+            while (true)
+            {
+                var page = await _mastodonService.GetStatusesPageAsync(MastodonPageSize, maxId);
+
+                if (page.Count == 0)
+                {
+                    _logger.LogInformation("Mastodon back-fill reached end of timeline after {Pages} pages.", pageCount);
+                    break;
+                }
+
+                pageCount++;
+                var toInsert = new List<FeedItemLog>();
+
+                foreach (var status in page)
+                {
+                    var createdAt = status.CreatedAt.DateTimeOffset.UtcDateTime;
+
+                    if (createdAt < cutoff)
+                    {
+                        _logger.LogInformation("Mastodon back-fill reached cut-off date after {Pages} pages.", pageCount);
+                        goto Done;
+                    }
+
+                    var externalId = $"mastodon_{status.Id}";
+                    if (!_feedItemLogStore.Exists(externalId))
+                    {
+                        toInsert.Add(new FeedItemLog
+                        {
+                            ExternalId = externalId,
+                            Source = "mastodon",
+                            CreatedAt = createdAt
+                        });
+                    }
+                }
+
+                if (toInsert.Count > 0)
+                {
+                    _feedItemLogStore.SaveRange(toInsert);
+                    totalInserted += toInsert.Count;
+                }
+
+                // Use the ID of the oldest status in the page as the cursor for the next page
+                maxId = page.Last().Id;
+
+                // Polite pause to avoid hammering the API
+                await Task.Delay(500);
+            }
+
+            Done:
+            _logger.LogInformation("Mastodon back-fill complete. Inserted {Count} items across {Pages} pages.", totalInserted, pageCount);
+        }
+    }
+}

--- a/H5YR.Core/Services/IMastodonService.cs
+++ b/H5YR.Core/Services/IMastodonService.cs
@@ -6,7 +6,7 @@ namespace H5YR.Core.Services
     public interface IMastodonService
     {
         Task<List<MastodonStatus>> GetStatuses(int limit, string? startId = null);
+        Task<List<MastodonStatus>> GetStatusesPageAsync(int limit, string? maxId);
         int GetPostCount();
-
     }
 }

--- a/H5YR.Core/Services/MastodonService.cs
+++ b/H5YR.Core/Services/MastodonService.cs
@@ -41,6 +41,29 @@ namespace H5YR.Core.Services
             return await posts!;
         }
 
+        public async Task<List<MastodonStatus>> GetStatusesPageAsync(int limit, string? maxId)
+        {
+            MastodonHttpService mastodon = MastodonHttpService.CreateFromDomain(FeedDomain);
+
+            MastodonGetHashtagTimelineOptions options = new()
+            {
+                Hashtag = FeedHashtag,
+                Limit = limit,
+                MaxId = maxId
+            };
+
+            try
+            {
+                MastodonStatusListResponse response = await mastodon.Timelines.GetHashtagTimelineAsync(options);
+                return response.Body.ToList();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed fetching paginated statuses from the Mastodon API (maxId={MaxId}).", maxId);
+                return new List<MastodonStatus>();
+            }
+        }
+
 
         private async Task<List<MastodonStatus>> LoadStatuses(int limit, string? startId)
         {

--- a/H5YR.Core/ViewComponents/MastodonViewComponent.cs
+++ b/H5YR.Core/ViewComponents/MastodonViewComponent.cs
@@ -1,4 +1,6 @@
-﻿using H5YR.Core.Extensions;
+﻿using H5YR.Core.Data.Entities;
+using H5YR.Core.Data.Interfaces;
+using H5YR.Core.Extensions;
 using H5YR.Core.Models;
 using H5YR.Core.Services;
 using H5YR.Core.Settings;
@@ -17,6 +19,7 @@ namespace H5YR.Core.ViewComponents
         private readonly IOptions<APISettings> _apiSettings;
         private readonly IMastodonService _mastodonService;
         private readonly IWidgetH5yrService _widgetH5yrService;
+        private readonly IFeedItemLogStore _feedItemLogStore;
 
         protected bool IsOffline => _apiSettings.Value.Offline == "true";
 
@@ -26,12 +29,14 @@ namespace H5YR.Core.ViewComponents
             ILogger<MastodonViewComponent> logger,
             IOptions<APISettings> apiSettings,
             IMastodonService mastodonService,
-            IWidgetH5yrService widgetH5yrService)
+            IWidgetH5yrService widgetH5yrService,
+            IFeedItemLogStore feedItemLogStore)
         {
             _logger = logger;
             _apiSettings = apiSettings;
             _mastodonService = mastodonService;
             _widgetH5yrService = widgetH5yrService;
+            _feedItemLogStore = feedItemLogStore;
         }
 
         public async Task<IViewComponentResult> InvokeAsync()
@@ -47,6 +52,9 @@ namespace H5YR.Core.ViewComponents
 
             // Build unified feed: merge Mastodon posts + widget h5yrs sorted by date
             var feedItems = BuildUnifiedFeed(statuses);
+
+            // Persist any new feed items to the log table for accurate date-based stats
+            LogNewFeedItems(feedItems);
 
             // Initialize a new model for the view component
             MastodonModel model = new(statuses, totalCount, feedItems);
@@ -80,6 +88,29 @@ namespace H5YR.Core.ViewComponents
                 .Concat(widgetItems)
                 .OrderByDescending(f => f.CreatedAt)
                 .ToList();
+        }
+
+        private void LogNewFeedItems(IReadOnlyList<FeedItem> feedItems)
+        {
+            foreach (var item in feedItems)
+            {
+                try
+                {
+                    if (!_feedItemLogStore.Exists(item.Id))
+                    {
+                        _feedItemLogStore.Save(new FeedItemLog
+                        {
+                            ExternalId = item.Id,
+                            Source = item.Source,
+                            CreatedAt = item.CreatedAt
+                        });
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error logging feed item {Id}", item.Id);
+                }
+            }
         }
 
         private async Task<IReadOnlyList<MastodonStatus>> GetStatuses()


### PR DESCRIPTION
Fixes : #87 

This pull request introduces a new unified logging and migration system for feed items, consolidating data from both Mastodon and widget sources into a single `FeedItemLog` table. It includes new components for database migration, backfilling existing data, and updates the community stats service to use this new log as the source of truth for statistics and activity timelines.

**Feed Item Logging Infrastructure:**

- Added the `FeedItemLog` entity, schema constants, and store interface/implementation to persist feed item metadata from multiple sources (`mastodon`, `widget`). (`H5YR.Core/Data/Entities/FeedItemLog.cs`, `H5YR.Core/Data/Constants/FeedItemLogSchemaConstants.cs`, `H5YR.Core/Data/Interfaces/IFeedItemLogStore.cs`, `H5YR.Core/Data/Stores/FeedItemLogStore.cs`) [[1]](diffhunk://#diff-be326ef3be5a7adc847d2eb5365c0dc016dd7259e9fcf9079c1e17f675e56259R1-R37) [[2]](diffhunk://#diff-cd354e8498ea2e5e45cd004ea13ac7d90645df8926b91a18cd93bc05fd440a14R1-R19) [[3]](diffhunk://#diff-ae0d60511f3816b2d55fdf47a9851429e2a893f67343419bb0d46dde917abc8fR1-R13) [[4]](diffhunk://#diff-7dc9ec81e27d89f97499177c0c1f2ff5bffd3f9901d552b50252f41708ba6626R1-R72)

- Introduced a database migration (`FeedItemLogCreateTableMigration`) and a migration component to ensure the `FeedItemLog` table is created on startup. (`H5YR.Core/Data/Migrations/FeedItemLogCreateTableMigration.cs`, `H5YR.Core/Composers/FeedItemLogStoreComposer.cs`) [[1]](diffhunk://#diff-36d0398678f9a9aa16cfc8eebed347cc085208e4a94db5c40543bdd1bab88c28R1-R39) [[2]](diffhunk://#diff-d2ca96f0e5e8218b68ff625f74f2cb11ee529fd843110cc84fdf37bd510589cdR1-R60)

**Data Backfill and Initialization:**

- Added `FeedItemLogBackfillService` and related async component to backfill log data from both widget and Mastodon sources, ensuring the log is populated with historical data. The backfill only runs once per environment. (`H5YR.Core/Services/FeedItemLogBackfillService.cs`, `H5YR.Core/Composers/FeedItemLogBackfillComposer.cs`) [[1]](diffhunk://#diff-423d5e53cb53a0a169d822dc3d9f683bda0663f5a184b5b66a32877249736ae6R1-R122) [[2]](diffhunk://#diff-317382a2e441ed49ed484b27f8986c72150868c2116436e859bd5acfc6ca39deR1-R75)

- Registered the new services and stores in the DI container. (`H5YR.Core/Composers/DiComposer.cs`)

**Community Stats Refactor:**

- Refactored `CommunityStatsService` to use `FeedItemLogStore` as the single source of truth for all activity counts and timelines, removing previous logic that combined separate counters and widget sources. (`H5YR.Core/Services/CommunityStatsService.cs`) [[1]](diffhunk://#diff-90f61a587dd641f297729e2589da2c47a0d82c6a9ee211a28ed25a496850b877L11-R47) [[2]](diffhunk://#diff-90f61a587dd641f297729e2589da2c47a0d82c6a9ee211a28ed25a496850b877R73) [[3]](diffhunk://#diff-90f61a587dd641f297729e2589da2c47a0d82c6a9ee211a28ed25a496850b877L132-R98)

**Mastodon Service Update:**

- Added a paginated status fetch method to `IMastodonService` to support efficient backfilling. (`H5YR.Core/Services/IMastodonService.cs`)