### PR TITLE
Fix issue with header z-index

### DIFF
--- a/H5YR/frontend/css/shared/header.scss
+++ b/H5YR/frontend/css/shared/header.scss
@@ -4,7 +4,7 @@
   position: absolute;
   top: 0;
   left: 0;
-
+  z-index: 100;
 
     &__inner {
         display: flex;


### PR DESCRIPTION
- Add `z-index: 100;` to the `.header` class.
     - This fixes the issue where the header renders beneath the hero svg, which was making it impossible to click some of the header links.

## Old Behaviour
The header renders beneath the hero SVG, making it impossible to click some of the header links.
<img width="2129" height="796" alt="h5yr_header_before" src="https://github.com/user-attachments/assets/7b55a6d2-f0a6-4860-ac0b-8c0231b8b0e9" />

## New Behaviour
The header renders above the hero SVG, making it possible to click all of the header links.
<img width="2129" height="796" alt="h5yr_header_after" src="https://github.com/user-attachments/assets/4ab96ebd-c2b9-44bb-9609-2e00120263e2" />
